### PR TITLE
Clarification and contextual link to the diagrams

### DIFF
--- a/solution_architecture.md
+++ b/solution_architecture.md
@@ -47,8 +47,8 @@ The app pursues two objectives: First, supporting individuals in finding out whe
 
 Reporting positive tests to the app is crucial for others to get informed about a relevant exposure and potential infection. On the other hand, a verification before the uploaded of diagnosis keys is required in order to prevent misuse. 
 There are two ways for receiving this verification: 
-1. Use of the integrated functionality of the Corona-Warn-App to retrieve the results of a SARS-CoV-2 test from a verification server (see Figure 4a). Through this integration, the positive test result is already verified and the diagnosis keys can be uploaded right after users have given their consent. 
-2. Use of a human-readable token (e.g. a number or a combination of words) and provide this as verification to the app. This token is called teleTAN (see Figure 4b).
+1. Use of the integrated functionality of the Corona-Warn-App to retrieve the results of a SARS-CoV-2 test from a verification server (see Figure 2, Step 4a). Through this integration, the positive test result is already verified and the diagnosis keys can be uploaded right after users have given their consent. 
+2. Use of a human-readable token (e.g. a number or a combination of words) and provide this as verification to the app. This token is called teleTAN (see Figure 2, Step 4b).
 
 ![Figure 2: Interaction flow for verification process](images/solution_architecture/figure_2.svg "Figure 2: Interaction flow for verification process")
 

--- a/solution_architecture.md
+++ b/solution_architecture.md
@@ -46,7 +46,9 @@ The app pursues two objectives: First, supporting individuals in finding out whe
 ### Retrieval of lab results and verification process
 
 Reporting positive tests to the app is crucial for others to get informed about a relevant exposure and potential infection. On the other hand, a verification before the uploaded of diagnosis keys is required in order to prevent misuse. 
-There are two main approaches for this verification: The first option is to use the integrated functionality of the Corona-Warn-App to retrieve the results of a SARS-CoV-2 test. Through this integration, the positive test result is already verified and the diagnosis keys can be uploaded right after users have given their consent. The second option is to receive a human-readable token (e.g. a number or a combination of words) and provide this as verification to the app. This token is called teleTAN.
+There are two ways for receiving this verification: 
+1. Use of the integrated functionality of the Corona-Warn-App to retrieve the results of a SARS-CoV-2 test from a verification server (see Figure 4a). Through this integration, the positive test result is already verified and the diagnosis keys can be uploaded right after users have given their consent. 
+2. Use of a human-readable token (e.g. a number or a combination of words) and provide this as verification to the app. This token is called teleTAN (see Figure 4b).
 
 ![Figure 2: Interaction flow for verification process](images/solution_architecture/figure_2.svg "Figure 2: Interaction flow for verification process")
 


### PR DESCRIPTION
`main approaches` implies that the app will eventually only use either option 1 or option 2. However, I am guessing the author meant that those are both options to be used in the production app.

I further highlighted the two options visually and removed clutter.