### PR TITLE
replacing incorrect use of citizens

### DIFF
--- a/solution_architecture.md
+++ b/solution_architecture.md
@@ -29,7 +29,7 @@ Assuming a close association of a mobile phone and its user, we equate the devic
 
 ## INTRODUCTION
 
-To reduce the spread of [COVID-19](https://www.ecdc.europa.eu/en/covid-19-pandemic) it is necessary to inform people about their close proximity to positively tested individuals. So far, health departments and citizens identified these in personal dialogues based on people’s memory, which led to a high number of unknown connections, e.g. when using public transport. 
+To reduce the spread of [COVID-19](https://www.ecdc.europa.eu/en/covid-19-pandemic) it is necessary to inform people about their close proximity to positively tested individuals. So far, health departments and persons identified these in personal dialogues based on people’s memory, which led to a high number of unknown connections, e.g. when using public transport. 
 
 ![Figure 1: High-level architecture overview](images/solution_architecture/figure_1.svg "Figure 1: High-level architecture overview")
 
@@ -56,7 +56,7 @@ This preexisting process for the processing of lab results includes that the doc
 
 The flow for using the app is as follows, referencing the steps from *Figure 2*:
 
-- **Step 1:** Citizens are using the Corona-Warn-App (i.e. broadcasting and collecting RPIs)
+- **Step 1:** Users of the Corona-Warn-App (i.e. broadcasting and collecting RPIs)
 	- (1) When a test is conducted, they receive an information flyer with a custom QR code. The code is either created on-site or is already available as a stack of pre-printed QR codes. The QR code contains a globally unique identifier (GUID).
 	- (2) Optionally, they can scan the QR code with the Corona-Warn-App (*Figure 3*, step 1) – if users decide against using the test retrieval functionality of the Corona-Warn-App, they still receive their test results through the regular channels explained before.
 	- (3) When the code is scanned, a web service call (REST) is placed against the Verification Server (*Figure 3*, step 2), linking the phone with the data from the QR code through a registration token, which is generated on the server  (*Figure 3*, step 3) and stored on the phone  (*Figure 3*, step 4).

--- a/solution_architecture.md
+++ b/solution_architecture.md
@@ -29,7 +29,7 @@ Assuming a close association of a mobile phone and its user, we equate the devic
 
 ## INTRODUCTION
 
-To reduce the spread of [COVID-19](https://www.ecdc.europa.eu/en/covid-19-pandemic) it is necessary to inform people about their close proximity to positively tested individuals. So far, health departments and persons identified these in personal dialogues based on people’s memory, which led to a high number of unknown connections, e.g. when using public transport. 
+To reduce the spread of [COVID-19](https://www.ecdc.europa.eu/en/covid-19-pandemic) it is necessary to inform people about their close proximity to positively tested individuals. So far, health departments and affected individuals identified these in personal dialogues based on people’s memory, which led to a high number of unknown connections, e.g. when using public transport. 
 
 ![Figure 1: High-level architecture overview](images/solution_architecture/figure_1.svg "Figure 1: High-level architecture overview")
 


### PR DESCRIPTION
I am guessing the author did not actually meant to use `citizens` (Staatsbuerger) in those two instances, since also non-citizen that reside in Germany are probably allowed, if not encouraged to use the app as well.