### PR TITLE
README.md links changed for cwa-server & cwa-app-android docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,11 @@ The project scope has been agreed on jointly by Deutsche Telekom AG and SAP SE a
 The technical documents are intended for a technical audience and represent the most recent state of the architecture. The solution architecture and concepts might change over time as external dependencies (e.g. the framework provided by Apple/Google) are still changing and new requirements need to be included or existing ones change. We appreciate feedback to all elements of these technical documents.
 
 - [Corona-Warn-App - Solution Architecture](solution_architecture.md)
-- [Corona-Warn-App Server Architecture](https://github.com/corona-warn-app/cwa-server/blob/master/docs/ARCHITECTURE.md)
+- [Corona-Warn-App Server Architecture](https://github.com/corona-warn-app/cwa-server/blob/main/docs/ARCHITECTURE.md)
 - [Corona-Warn-App Verification Server Software Design](https://github.com/corona-warn-app/cwa-verification-server/blob/master/docs/architecture-overview.md)
 - [Corona-Warn-App Verification Portal Server Software Design](https://github.com/corona-warn-app/cwa-verification-portal/blob/master/docs/architecture-overview.md)
 - [Corona-Warn-App Test Result Server Software Design](https://github.com/corona-warn-app/cwa-testresult-server/blob/master/docs/architecture-overview.md)
-- [Corona-Warn-App Mobile Client (Android) Architecture](https://github.com/corona-warn-app/cwa-app-android/blob/master/docs/architecture-overview.md)
+- [Corona-Warn-App Mobile Client (Android) Architecture](https://github.com/corona-warn-app/cwa-app-android/blob/main/docs/architecture-overview.md)
 - [Corona-Warn-App Mobile Client (iOS) Architecture](https://github.com/corona-warn-app/cwa-app-ios/blob/main/docs/architecture-overview.md)
 - [Criteria for the Evaluation of Contact Tracing Apps](pruefsteine.md)
 - [Corona-Warn-App Security Overview](overview-security.md)


### PR DESCRIPTION
PR https://github.com/corona-warn-app/cwa-documentation/pull/449 fixed the out-dated documentation link 
from https://github.com/corona-warn-app/cwa-app-ios/tree/master to
https://github.com/corona-warn-app/cwa-app-ios/tree/main

This PR addresses the renaming of two further default repositories
from
https://github.com/corona-warn-app/cwa-server/tree/master to
https://github.com/corona-warn-app/cwa-server/tree/main
and from
https://github.com/corona-warn-app/cwa-app-android/tree/master to
https://github.com/corona-warn-app/cwa-app-android/tree/main

The links in the README.md which pointed to the corresponding old master branch of cwa-server and cwa-app-android respectively caused the warning message:
`"Branch not found, redirected to default branch."`
to be shown, before the file was found and displayed.

This PR causes the files to be opened without warning messages.