### PR TITLE
Remove trailing whitespace from solution_architecture.md (resolves markdownlint fail)

### DIFF
--- a/solution_architecture.md
+++ b/solution_architecture.md
@@ -277,7 +277,7 @@ If the back end calls from the mobile applications cannot be spread as evenly as
 
 A definite prerequisite for compatibility is that the identifiers of the mobile devices can be matched, i.e. the GAEN framework by Apple and Google is being used.
 
-[Most European countries are developing similar contact tracing apps](https://ec.europa.eu/info/live-work-travel-eu/health/coronavirus-response/travel-during-coronavirus-pandemic/mobile-contact-tracing-apps-eu-member-states_en). These apps may use the common frameworks by Google and Apple, enabling transmission and detection of GAEN format diagnosis keys between devices running different contact tracing applications. 
+[Most European countries are developing similar contact tracing apps](https://ec.europa.eu/info/live-work-travel-eu/health/coronavirus-response/travel-during-coronavirus-pandemic/mobile-contact-tracing-apps-eu-member-states_en). These apps may use the common frameworks by Google and Apple, enabling transmission and detection of GAEN format diagnosis keys between devices running different contact tracing applications.
 Each country has its own separate database, which contains the keys from infected individuals. In order to coordinate exposure information between countries, a common service is required to enable interoperability.
 The [European Federation Gateway Service (EFGS)](https://github.com/eu-federation-gateway-service/efgs-federation-gateway) enables interoperability of diagnosis keys between the connected country backend servers.
 
@@ -292,7 +292,7 @@ In the example above, user A from country A travels to country B and afterwards 
 Devices only communicate with their country's backend. That country's backend is then responsible to send relevant keys to the EFGS.
 All connected countries provide keys to the EFGS. The EFGS then makes available relevant keys to each additional connected country's backend. Notifications and alerts are handled by each individual country's backend.
 The EFGS stores information of all currently infected citizens along with a list of countries they visited.
-In order for the EFGS to function correctly, all users must specify their visited countries correctly (either manually or automatically). 
+In order for the EFGS to function correctly, all users must specify their visited countries correctly (either manually or automatically).
 
 ## LIMITATIONS
 


### PR DESCRIPTION
This PR removes trailing whitespace in lines 280 and 295 from [solution_architecture.md](https://github.com/corona-warn-app/cwa-documentation/blob/master/solution_architecture.md) to resolve the issue of failed markdownlint check.

One of the failures of [Build check](https://github.com/corona-warn-app/cwa-documentation/runs/1611961573) is
```
solution_architecture.md:280:421 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
solution_architecture.md:295:138 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
```

The problem was introduced by PR #462 "Added Interoperability information of EFGS" and the error condition was not resolved at the time of the merge.

---
The full failing markdownlint check is

```
Run npm run-script markdownlint
  npm run-script markdownlint
  shell: /bin/bash -e {0}

> docs@1.0.0 markdownlint /home/runner/work/cwa-documentation/cwa-documentation
> markdownlint '**/*.md' --ignore node_modules

solution_architecture.md:280:421 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
solution_architecture.md:295:138 MD009/no-trailing-spaces Trailing spaces [Expected: 0 or 2; Actual: 1]
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! docs@1.0.0 markdownlint: `markdownlint '**/*.md' --ignore node_modules`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the docs@1.0.0 markdownlint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/runner/.npm/_logs/2020-12-26T19_41_19_567Z-debug.log
Error: Process completed with exit code 1.
```