### PR TITLE
Include table with links to other repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,12 +93,12 @@ For an easier understanding of the used acronyms and special terms in our docume
 | [cwa-app-ios]       | Native iOS app using the Apple/Google exposure notification API.      |
 | [cwa-app-android]   | Native Android app using the Apple/Google exposure notification API.  |
 | [cwa-wishlist]      | Community feature requests.                                           |
-| [cwa-website]       | The official website for the Corona-Warn-App                          |
+| [cwa-website]       | The official website for the Corona-Warn-App.                         |
 | [cwa-server]        | Backend implementation for the Apple/Google exposure notification API.|
 | [cwa-verification-server] | Backend implementation of the verification process.             |
-| [cwa-verification-portal] | The portal to interact with the verification server             |
-| [cwa-verification-iam]    | The identity and access management to interact with the verification server |
-| [cwa-testresult-server]   | Receives the test results from connected laboratories           |
+| [cwa-verification-portal] | The portal to interact with the verification server.            |
+| [cwa-verification-iam]    | The identity and access management to interact with the verification server. |
+| [cwa-testresult-server]   | Receives the test results from connected laboratories.          |
 
 
 [cwa-documentation]: https://github.com/corona-warn-app/cwa-documentation

--- a/README.md
+++ b/README.md
@@ -85,6 +85,24 @@ To be published:
 
 For an easier understanding of the used acronyms and special terms in our documents please see our [glossary](glossary.md).
 
+## Repositories
+
+| Repository          | Description                                                           |
+| ------------------- | --------------------------------------------------------------------- |
+| [cwa-documentation] | Project overview, general documentation, and white papers.            |
+| [cwa-wishlist]      | Community feature requests.                                           |
+| [cwa-app-ios]       | Native iOS app using the Apple/Google exposure notification API.      |
+| [cwa-app-android]   | Native Android app using the Apple/Google exposure notification API.  |
+| [cwa-server]        | Backend implementation for the Apple/Google exposure notification API.|
+| [cwa-verification-server] | Backend implementation of the verification process. |
+
+[cwa-verification-server]: https://github.com/corona-warn-app/cwa-verification-server
+[cwa-documentation]: https://github.com/corona-warn-app/cwa-documentation
+[cwa-wishlist]: https://github.com/corona-warn-app/cwa-wishlist
+[cwa-app-ios]: https://github.com/corona-warn-app/cwa-app-ios
+[cwa-app-android]: https://github.com/corona-warn-app/cwa-app-android
+[cwa-server]: https://github.com/corona-warn-app/cwa-server
+
 ## Licensing
 
 Copyright (c) 2020 Deutsche Telekom AG and SAP SE or an SAP affiliate company.

--- a/README.md
+++ b/README.md
@@ -90,18 +90,27 @@ For an easier understanding of the used acronyms and special terms in our docume
 | Repository          | Description                                                           |
 | ------------------- | --------------------------------------------------------------------- |
 | [cwa-documentation] | Project overview, general documentation, and white papers.            |
-| [cwa-wishlist]      | Community feature requests.                                           |
 | [cwa-app-ios]       | Native iOS app using the Apple/Google exposure notification API.      |
 | [cwa-app-android]   | Native Android app using the Apple/Google exposure notification API.  |
+| [cwa-wishlist]      | Community feature requests.                                           |
+| [cwa-website]       | The official website for the Corona-Warn-App                          |
 | [cwa-server]        | Backend implementation for the Apple/Google exposure notification API.|
-| [cwa-verification-server] | Backend implementation of the verification process. |
+| [cwa-verification-server] | Backend implementation of the verification process.             |
+| [cwa-verification-portal] | The portal to interact with the verification server             |
+| [cwa-verification-iam]    | The identy and access management to interact with the verification server |
+| [cwa-testresult-server]   | Receives the test results from connected laboratories           |
 
-[cwa-verification-server]: https://github.com/corona-warn-app/cwa-verification-server
+
 [cwa-documentation]: https://github.com/corona-warn-app/cwa-documentation
-[cwa-wishlist]: https://github.com/corona-warn-app/cwa-wishlist
 [cwa-app-ios]: https://github.com/corona-warn-app/cwa-app-ios
 [cwa-app-android]: https://github.com/corona-warn-app/cwa-app-android
+[cwa-wishlist]: https://github.com/corona-warn-app/cwa-wishlist
+[cwa-website]: https://github.com/corona-warn-app/cwa-website
 [cwa-server]: https://github.com/corona-warn-app/cwa-server
+[cwa-verification-server]: https://github.com/corona-warn-app/cwa-verification-server
+[cwa-verification-portal]: https://github.com/corona-warn-app/cwa-verification-portal
+[cwa-verification-iam]: https://github.com/corona-warn-app/cwa-verification-iam
+[cwa-testresult-server]: https://github.com/corona-warn-app/cwa-testresult-server
 
 ## Licensing
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ For an easier understanding of the used acronyms and special terms in our docume
 | [cwa-server]        | Backend implementation for the Apple/Google exposure notification API.|
 | [cwa-verification-server] | Backend implementation of the verification process.             |
 | [cwa-verification-portal] | The portal to interact with the verification server             |
-| [cwa-verification-iam]    | The identy and access management to interact with the verification server |
+| [cwa-verification-iam]    | The identity and access management to interact with the verification server |
 | [cwa-testresult-server]   | Receives the test results from connected laboratories           |
 
 


### PR DESCRIPTION
This PR adds a table with the links to other repos to the README.md file.
This is already done i.e. in the [iOS-Repo](https://github.com/corona-warn-app/cwa-app-ios/blob/release/1.11.x/README.md)