### PR TITLE
Fix failing link to Pan-European Privacy-Preserving Proximity Tracing (PEPP-PT) site (fixes #490)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The German government has comissioned SAP and Deutsche Telekom to develop the Co
 
 ## Credits
 
-We'd like to thank all the partners who have been involved in this enormous project from the beginning. The project would not be where it is today without all the exploration and great work that had already been done around the [PEPP-PT](https://www.pepp-pt.org/) approach by partners on a European and national level. We will build on top of some of these components and appreciate how everyone is dedicated to making this new approach successful. Moreover, we would like to thank GitHub for their great support.
+We'd like to thank all the partners who have been involved in this enormous project from the beginning. The project would not be where it is today without all the exploration and great work that had already been done around the [PEPP-PT](https://github.com/pepp-pt/pepp-pt-documentation) approach by partners on a European and national level. We will build on top of some of these components and appreciate how everyone is dedicated to making this new approach successful. Moreover, we would like to thank GitHub for their great support.
 
 ## Data Privacy
 

--- a/glossary.md
+++ b/glossary.md
@@ -23,7 +23,7 @@ This overview provides a description for all acronyms and special terms which ar
 | GUID | Acronym for "[Globally Unique Identifier](https://en.wikipedia.org/wiki/Universally_unique_identifier)". |
 | IfSG | The [German Prevention and Control Act of infectious diseases among humans](https://www.gesetze-im-internet.de/ifsg/index.html), acronym for "Infektionsschutzgesetz", long term: "Gesetz zur Verhütung und Bekämpfung von Infektionskrankheiten beim Menschen". |
 | OTC | Acronym for "[Open Telekom Cloud](https://open-telekom-cloud.com/)"
-| PEPP-PT | [Pan-European Privacy-Preserving Proximity Tracing](https://www.pepp-pt.org/), formerly endorsed approach to a COVID-19 exposure notification app for Germany. |
+| PEPP-PT | [Pan-European Privacy-Preserving Proximity Tracing](https://github.com/pepp-pt/pepp-pt-documentation), formerly endorsed approach to a COVID-19 exposure notification app for Germany. |
 | QR Code | Acronym for [Quick Response Code](https://en.wikipedia.org/wiki/QR_code), a two-dimensional/matrix barcode used in the Corona-Warn-App, handed out by the test center after a test was conducted. See our [solution architecture document](solution_architecture.md) for details. |
 | Registration Token | Used to a) link the mobile phone with the data from the QR Code and b) generate a TAN which is needed to finally perform the upload of the diagnosis keys to the Corona-Warn-App-Server. See our [solution architecture document](solution_architecture.md) for details. |
 | REST | Acronym for "[Representational State Transfer](https://en.wikipedia.org/wiki/Representational_state_transfer)". |

--- a/translations/README.de.md
+++ b/translations/README.de.md
@@ -31,7 +31,7 @@ Die deutsche Regierung hat SAP und die Deutsche Telekom beauftragt, die Corona-W
 
 ## Danksagungen
 
-Wir möchten allen danken, die an diesem wichtigen Projekt gleich von Beginn an beteiligt waren. Wir wären nicht da, wo wir heute sind, wenn wir durch viele Beiträge auf europäischer und nationaler Ebene nicht bereits so große Fortschritte mit [PEPP-PT](https://www.pepp-pt.org/) erzielt hätten. Wir setzen auf einigen dieser Komponenten auf und sind sehr dankbar dafür, mit wie viel Einsatz sich alle Beteiligten für den Erfolg dieses neuen Ansatzes einsetzen. Darüber hinaus bedanken wir uns bei GitHub für die großartige Unterstützung.
+Wir möchten allen danken, die an diesem wichtigen Projekt gleich von Beginn an beteiligt waren. Wir wären nicht da, wo wir heute sind, wenn wir durch viele Beiträge auf europäischer und nationaler Ebene nicht bereits so große Fortschritte mit [PEPP-PT](https://github.com/pepp-pt/pepp-pt-documentation) erzielt hätten. Wir setzen auf einigen dieser Komponenten auf und sind sehr dankbar dafür, mit wie viel Einsatz sich alle Beteiligten für den Erfolg dieses neuen Ansatzes einsetzen. Darüber hinaus bedanken wir uns bei GitHub für die großartige Unterstützung.
 
 ## Datenschutz
 


### PR DESCRIPTION
### Summary
This PR mitigates the failing hyperlink to the Pan-European Privacy-Preserving Proximity Tracing (PEPP-PT) website https://www.pepp-pt.org/. 

### Problem
The web site https://www.pepp-pt.org/ responds with a 404 file not found error, followed by a message "Looks Like This Domain Isn't Connected To A Website Yet!" from https://www.wix.com/.

### Resolution
The non-working link https://www.pepp-pt.org/ is replaced by the working link https://github.com/pepp-pt/pepp-pt-documentation in all documents on https://github.com/corona-warn-app/cwa-documentation which contain the failing link.

### Tests
npm run-script checklinks now runs successfully on this repository (tested locally) and via https://github.com/MikeMcC399/cwa-documentation/blob/master/.github/workflows/checks.yml running in the repository fork.

Successful run is logged on https://github.com/MikeMcC399/cwa-documentation/actions/runs/450812003