### PR TITLE
Delete line 103 (empty line) in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ For an easier understanding of the used acronyms and special terms in our docume
 | [cwa-verification-iam]    | The identity and access management to interact with the verification server. |
 | [cwa-testresult-server]   | Receives the test results from connected laboratories.          |
 
-
 [cwa-documentation]: https://github.com/corona-warn-app/cwa-documentation
 [cwa-app-ios]: https://github.com/corona-warn-app/cwa-app-ios
 [cwa-app-android]: https://github.com/corona-warn-app/cwa-app-android


### PR DESCRIPTION
I made a mistake in #493, there was one empty line to much in the REAMDE.md file, because of this the checks were failing. See https://github.com/corona-warn-app/cwa-documentation/pull/493#issuecomment-753448739. 

This PR fixes this. 
