### PR TITLE
Disable failing markdown-link-check for bundesregierung.de site (closes #542)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,10 @@ You may obtain a copy of the License at https://www.apache.org/licenses/LICENSE-
 
 Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the [LICENSE](./LICENSE) for the specific language governing permissions and limitations under the License.
 
+<!-- The website of the Bundesregierung has implemented additional security which causes a 503 error (service unavailable) when any link on their site is tested automatically. -->
+<!-- markdown-link-check-disable -->
 The "Corona-Warn-App" logo is a registered trademark of The Press and Information Office of the Federal Government. For more information please see [bundesregierung.de](https://www.bundesregierung.de/breg-en/federal-government/federal-press-office).
+<!-- markdown-link-check-enable -->
 
 ## How to Contribute
 

--- a/translations/README.de.md
+++ b/translations/README.de.md
@@ -73,7 +73,10 @@ Eine Kopie der Lizenz erhalten Sie unter https://www.apache.org/licenses/LICENSE
 
 Sofern nicht durch anwendbares Recht gefordert oder schriftlich vereinbart, wird jede unter der Lizenz bereitgestellte Software „OHNE MÄNGELGEWÄHR“ UND OHNE AUSDRÜCKLICHE ODER STILLSCHWEIGENDE GARANTIE JEGLICHER ART bereitgestellt. Die genauen Angaben zu Genehmigungen und Einschränkungen unter der Lizenz finden Sie in der [LIZENZ](../LICENSE).
 
+<!-- The website of the Bundesregierung has implemented additional security which causes a 503 error (service unavailable) when any link on their site is tested automatically. -->
+<!-- markdown-link-check-disable -->
 Das "Corona-Warn-App"-Logo ist eine registrierte Wort-/Bildmarke des Presse- und Informationsamts der Bundesregierung. Weitere Informationen finden Sie unter [bundesregierung.de](https://www.bundesregierung.de/breg-de/bundesregierung/bundespresseamt).
+<!-- markdown-link-check-enable -->
 
 ## Informationen zur Teilnahme
 


### PR DESCRIPTION
This PR disables link checking for the links:

- `[bundesregierung.de]https://www.bundesregierung.de/breg-en/federal-government/federal-press-office)`
- `[bundesregierung.de](https://www.bundesregierung.de/breg-de/bundesregierung/bundespresseamt)` and

in 

- https://github.com/corona-warn-app/cwa-documentation/blob/master/README.md and
- https://github.com/corona-warn-app/cwa-documentation/blob/master/translations/README.de.md

The npm package [markdown-link-check](https://www.npmjs.com/package/markdown-link-check) fails when checking any links to [bundesregierung.de](https://www.bundesregierung.de) due to new security on this site. The check returns a 503 error and declares the link dead. This causes the complete pull_request check to fail, marking any new commits with a failed red ❌.

See https://github.com/corona-warn-app/cwa-documentation/issues/542#issuecomment-795571682 for more information about the reasons behind the error.

The checks have been disabled in this PR using comments in the .md files, only for the paragraphs with the problematic links. All other links are checked as before.

`<!-- markdown-link-check-disable --> disables markdown link check. <!-- markdown-link-check-enable --> reenables markdown link check. `