### PR TITLE
Add markdown file to ui_screens folder

### DIFF
--- a/images/ui_screens/Outdated.md
+++ b/images/ui_screens/Outdated.md
@@ -1,0 +1,1 @@
+Please note that these screenshots are outdated. More information can be found [here](https://github.com/corona-warn-app/cwa-documentation/blob/master/ui_screens.md#screens).

--- a/images/ui_screens/Outdated.md
+++ b/images/ui_screens/Outdated.md
@@ -1,1 +1,1 @@
-Please note that the screenshots in this folder are outdated. More information can be found [here](https://github.com/corona-warn-app/cwa-documentation/blob/master/ui_screens.md#screens).
+Please note that the screenshots in this folder and it's subfolders are outdated. More information can be found [here](https://github.com/corona-warn-app/cwa-documentation/blob/master/ui_screens.md#screens).

--- a/images/ui_screens/Outdated.md
+++ b/images/ui_screens/Outdated.md
@@ -1,1 +1,1 @@
-Please note that these screenshots are outdated. More information can be found [here](https://github.com/corona-warn-app/cwa-documentation/blob/master/ui_screens.md#screens).
+Please note that the screenshots in this folder are outdated. More information can be found [here](https://github.com/corona-warn-app/cwa-documentation/blob/master/ui_screens.md#screens).


### PR DESCRIPTION
This PR adds a markdown file to https://github.com/corona-warn-app/cwa-documentation/tree/master/images/ui_screens which informs that these screenshots are outdated.

Related #508