### PR TITLE
Add information reg. out of date screenshots to "ui_screens" folder

### DIFF
--- a/images/ui_screens/Outdated.md
+++ b/images/ui_screens/Outdated.md
@@ -1,5 +1,5 @@
 # Outdated screenshots
 
-Please note that the screenshots in this folder and it's subfolders are outdated.
+Please note that the screenshots in this folder and its subfolders are outdated.
 
 Here you can find screenshots of some of the features that the Corona-Warn-App offers in the current release: [Take a Look](https://www.coronawarn.app/en/screenshots/). The corresponding German screenshots can be found here: [Machen Sie sich selbst ein Bild](https://www.coronawarn.app/de/screenshots/).

--- a/images/ui_screens/Outdated.md
+++ b/images/ui_screens/Outdated.md
@@ -1,0 +1,1 @@
+Please note that these screenshots are outdated. More information can be found [here](https://github.com/corona-warn-app/cwa-documentation/blob/master/ui_screens.md#screens).

--- a/images/ui_screens/Outdated.md
+++ b/images/ui_screens/Outdated.md
@@ -1,5 +1,5 @@
 ## Outdated screenshots
 
-Please note that the screenshots in this folder and it's subfolders are outdated. 
+Please note that the screenshots in this folder and it's subfolders are outdated.
 
 Here you can find screenshots of some of the features that the Corona-Warn-App offers in the current release: [Take a Look](https://www.coronawarn.app/en/screenshots/). The corresponding German screenshots can be found here: [Machen Sie sich selbst ein Bild](https://www.coronawarn.app/de/screenshots/).

--- a/images/ui_screens/Outdated.md
+++ b/images/ui_screens/Outdated.md
@@ -1,1 +1,1 @@
-Please note that the screenshots in this folder are outdated. More information can be found [here](https://github.com/corona-warn-app/cwa-documentation/blob/master/ui_screens.md#screens).
+Please note that the screenshots in this folder and it's subfolders are outdated. More information can be found [here](https://github.com/corona-warn-app/cwa-documentation/blob/master/ui_screens.md#screens).

--- a/images/ui_screens/Outdated.md
+++ b/images/ui_screens/Outdated.md
@@ -1,1 +1,1 @@
-Please note that these screenshots are outdated. More information can be found [here](https://github.com/corona-warn-app/cwa-documentation/blob/master/ui_screens.md#screens).
+Please note that the screenshots in this folder are outdated. More information can be found [here](https://github.com/corona-warn-app/cwa-documentation/blob/master/ui_screens.md#screens).

--- a/images/ui_screens/Outdated.md
+++ b/images/ui_screens/Outdated.md
@@ -1,4 +1,4 @@
-## Outdated screenshots
+# Outdated screenshots
 
 Please note that the screenshots in this folder and it's subfolders are outdated.
 

--- a/images/ui_screens/Outdated.md
+++ b/images/ui_screens/Outdated.md
@@ -1,1 +1,5 @@
-Please note that the screenshots in this folder and it's subfolders are outdated. More information can be found [here](https://github.com/corona-warn-app/cwa-documentation/blob/master/ui_screens.md#screens).
+## Outdated screenshots
+
+Please note that the screenshots in this folder and it's subfolders are outdated. 
+
+Here you can find screenshots of some of the features that the Corona-Warn-App offers in the current release: [Take a Look](https://www.coronawarn.app/en/screenshots/). The corresponding German screenshots can be found here: [Machen Sie sich selbst ein Bild](https://www.coronawarn.app/de/screenshots/).


### PR DESCRIPTION
This PR adds a markdown file to https://github.com/corona-warn-app/cwa-documentation/tree/master/images/ui_screens which informs that these screenshots are outdated.

Related: #508 

Follow up PR to #559