### PR TITLE
Fix markdownlint in event_registration.md 

### DIFF
--- a/event_registration.md
+++ b/event_registration.md
@@ -127,8 +127,11 @@ NotifyMe CH:
 https://qr.notify-me.ch?v=2#bm90aWZ5bWU
 CLEA FR:
 https://tac.gouv.fr?v=1#Y2xlYQ
+
 ```
-```
+
+```bash
+
 #Example:
 https://e.coronawarn.app?v=1#CAESEwgBEgdGcmlzZXVyGgZCZXJsaW4adggBEmCDAszMTXne1DAA5_YxmhRdd_NZN2VKl9L32Jl9-ZybE4b2eNIrhFOKYU4XAOHq3RPLDxdHTW6ANiO24rCOO4rj06HzcVZy3pel58-L1KSPG-_PneL2BoyZQRz3qlu2hoAaEATXwzyyIshzBHREtsdmc6kiBggBEAUYeA
 
@@ -150,6 +153,7 @@ Vendor Data Example:
   defaultCheckInLengthInMinutes: 120
 
 ```
+
 ### QR Code Compatibility with Other Contract Tracing Apps in Germany
 
 Other contact tracing apps in Germany that leverage QR codes for Presence Tracing can integrate with CWA by creating QR codes according to the following pattern:


### PR DESCRIPTION
This PR fixes the following markdownlint errors in https://github.com/corona-warn-app/cwa-documentation/blob/master/event_registration.md:

```
event_registration.md:130 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
9
event_registration.md:131 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
10
event_registration.md:131 MD040/fenced-code-language Fenced code blocks should have a language specified [Context: "```"]
11
event_registration.md:152 MD031/blanks-around-fences Fenced code blocks should be surrounded by blank lines [Context: "```"]
12
event_registration.md:153 MD022/blanks-around-headings/blanks-around-headers Headings should be surrounded by blank lines [Expected: 1; Actual: 0; Above] [Context: "### QR Code Compatibility with Other Contract Tracing Apps in Germany"]
13
```

I specified batch as language, if it should be text please let me know (cc @MikeMcC39 since you already fixed markdownlint in this document once (#557)