### PR TITLE
Fix codeowners and add bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_bugs.md
+++ b/.github/ISSUE_TEMPLATE/02_bugs.md
@@ -1,0 +1,53 @@
+---
+name: "\U0001F6A8 Bug Report"
+about: Did you come across a bug or unexpected behaviour differing from the docs?
+labels: bug
+
+---
+<!--
+Thanks for reporting a bug 🙌 ❤️
+
+Before opening a new issue, please make sure that we do not have any duplicates already open. You can ensure this by searching the issue list for this repository. If there is a duplicate, please close your issue and add a comment to the existing issue instead.
+
+Also, be sure to check our documentation first: https://github.com/corona-warn-app/cwa-documentation
+-->
+
+## Avoid duplicates
+* [ ] Bug is not mentioned in the [FAQ](https://www.coronawarn.app/en/faq/)
+* [ ] Bug affects both Android **and** iOS, for specific issues / questions that apply only to one operating system, please raise them in the respective repositories:
+    * [Android repository](https://github.com/corona-warn-app/cwa-app-android)
+    * [iOS repository](https://github.com/corona-warn-app/cwa-app-ios)
+* [ ] Bug is not already reported in another issue
+
+## Technical details
+
+- Device name:
+- iOS/Android version:
+- App version:
+
+## Describe the bug
+
+<!-- Describe your issue, but please be descriptive! Thanks again 🙌 ❤️ -->
+
+## Steps to reproduce the issue
+
+<!-- include screenshots, logs, code or other info to help explain your problem -->
+
+<!--
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+-->
+
+## Expected behaviour
+
+<!-- A clear and concise description of what you expected to happen. -->
+
+## Possible Fix
+
+<!--- Not obligatory, but suggest a fix or reason for the bug -->
+
+## Additional context
+
+<!-- Add any other context about the problem here. -->

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -5,15 +5,15 @@
 # For more details, read the following article on GitHub: https://help.github.com/articles/about-codeowners/.
 
 # These are the default owners for the whole content of this repository. The default owners are automatically added as reviewers when you open a pull request, unless different owners are specified in the file.
-* @SebastianWolf-SAP @tkowark
+* @corona-warn-app/cwa-moderators
 
 # Solution architecture document and its translations
-solution_architecture*.md @tklingbeil @SebastianWolf-SAP @tkowark
-/images/solution_architecture/ @tklingbeil @SebastianWolf-SAP @tkowark
+solution_architecture*.md @tklingbeil @corona-warn-app/cwa-moderators
+/images/solution_architecture/ @tklingbeil @corona-warn-app/cwa-moderators
 
 # Epidemiological Motivation of the Transmission Risk Level
 transmission_risk* @kirchnergo @hoehleatsu @weidemannf @dirkschumacher @benzlerj
 
 # How does the Corona-Warn-App identify an increased risk?
-cwa-risk* @benzlerj @hoehleatsu @kirchnergo @SebastianWolf-SAP
-translations/cwa-risk* @benzlerj @hoehleatsu @kirchnergo @SebastianWolf-SAP
+cwa-risk* @benzlerj @hoehleatsu @kirchnergo @corona-warn-app/cwa-moderators
+translations/cwa-risk* @benzlerj @hoehleatsu @kirchnergo @corona-warn-app/cwa-moderators


### PR DESCRIPTION
Fixes https://github.com/corona-warn-app/cwa-documentation/issues/575

The bug template is the one from the Android repository, but now includes hints for the Android and iOS repositories

Fixes https://github.com/corona-warn-app/cwa-documentation/issues/440

This changes some individual reviewers to Github team references.
