### PR TITLE
Bump copyright year in German README

### DIFF
--- a/translations/README.de.md
+++ b/translations/README.de.md
@@ -65,7 +65,7 @@ Die technischen Dokumente sind für ein technisches Publikum bestimmt und reprä
 
 ## Lizenzierung
 
-Copyright (c) 2020 Deutsche Telekom AG und SAP SE oder ein SAP-Konzernunternehmen.
+Copyright (c) 2020-2021 Deutsche Telekom AG und SAP SE oder ein SAP-Konzernunternehmen.
 
 Lizenziert unter **Apache-Lizenz, Version 2.0** (die "Lizenz"). Sie dürfen diese Datei ausschließlich im Einklang mit der Lizenz verwenden.
 


### PR DESCRIPTION
This PR bumps the copyright year in the German README so that it now says "2020-2021" and not only "2020".

This is already done in the [English README](https://github.com/corona-warn-app/cwa-documentation/blob/master/README.md). 