### PR TITLE
Add links to other glossaries (closes #670)

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -36,3 +36,17 @@ This overview provides a description for all acronyms and special terms which ar
 | TCN | The [TCN Coalition](https://tcn-coalition.org/) is a global community of people to support exposure notification apps during the COVID-19 pandemic. |
 | TEK | Acronym for "[Temporary Exposure Key](https://covid19-static.cdn-apple.com/applications/covid19/current/static/contact-tracing/pdf/ExposureNotification-BluetoothSpecificationv1.2.pdf)". A key that’s generated every 24 hours for privacy consideration. |
 | teleTAN | Authorizes the upload of diagnosis keys from the app to the Corona-Warn-App Server if the test has returned a positive result and if the device wasn't linked using the QR Code. If the authorization is successful, the server will issue a registration token. See our [solution architecture document](solution_architecture.md) for details. |
+
+## Other Glossaries
+
+### Technical FAQ Site
+
+- [English Glossary](https://www.coronawarn.app/en/faq/#glossary)
+- [German Glossar](https://www.coronawarn.app/de/faq/#glossary)
+
+### Federal Government (Bundesregierung) FAQ Site
+
+To access the glossaries, scroll down the page to the Glossary / Glossar section:
+
+- [English FAQs](https://www.bundesregierung.de/corona-warn-app-faq-englisch)
+- [German FAQs](https://www.bundesregierung.de/corona-warn-app-faq)


### PR DESCRIPTION
This PR resolves #670 by adding links from the repository [glossary.md ](https://github.com/corona-warn-app/cwa-documentation/blob/master/glossary.md) to

### Technical FAQ Site

- [English Glossary](https://www.coronawarn.app/en/faq/#glossary)
- [German Glossar](https://www.coronawarn.app/de/faq/#glossary)

### Federal Government (Bundesregierung) FAQ Site

- [English FAQs](https://www.bundesregierung.de/corona-warn-app-faq-englisch)
- [German FAQs](https://www.bundesregierung.de/corona-warn-app-faq)

Unfortunately the Federal Government's website has hardcoded a file date into the glossary link, so I didn't link directly to the respective language's glossary, instead I linked to the FAQ page housing the glossary and provided instructions to scroll down to the glossary. (Hard-coding a date or version id into a hyperlink is in general not good practice as it does not promote persistency.) The glossary has not undergone any updates though since June 2020.