### PR TITLE
fix protobuf message

### DIFF
--- a/event_registration.md
+++ b/event_registration.md
@@ -63,7 +63,7 @@ message QRCodePayload {
   uint32 version = 1;
   TraceLocation locationData = 2;
   CrowdNotifierData crowdNotifierData = 3;
-  CWALocationData vendordata = 4;
+  CWALocationData vendorData = 4;
 }
 
 message TraceLocation {

--- a/event_registration.md
+++ b/event_registration.md
@@ -63,7 +63,8 @@ message QRCodePayload {
   uint32 version = 1;
   TraceLocation locationData = 2;
   CrowdNotifierData crowdNotifierData = 3;
-  CWALocationData vendorData = 4;
+  // byte sequence of CWALocationData
+  bytes vendorData = 4;
 }
 
 message TraceLocation {

--- a/event_registration.md
+++ b/event_registration.md
@@ -63,8 +63,7 @@ message QRCodePayload {
   uint32 version = 1;
   TraceLocation locationData = 2;
   CrowdNotifierData crowdNotifierData = 3;
-  // byte sequence of CWALocationData
-  bytes countryData = 4;
+  CWALocationData vendordata = 4;
 }
 
 message TraceLocation {


### PR DESCRIPTION
the current documentation doesnt represent the actual links in the qr codes.
this pr changes ```bytes countryData = 4;``` to ```CWALocationData vendorData = 4;``` 

for reference: 
* [CWA](https://github.com/corona-warn-app/cwa-app-android/blob/aa9dace7ea3b40932321882cc962ec92caee0e1b/Corona-Warn-App/src/main/java/de/rki/coronawarnapp/presencetracing/checkins/qrcode/QrCodePayload.kt#L15)
* [luca](https://gitlab.com/lucaapp/cwa-event/-/blob/master/src/eventregistration.ts#L137)