### PR TITLE
Lock repository to lts/fermium (node v14)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,6 +14,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Setup Node.js environment (v14)
+        uses: actions/setup-node@v2
+        with:
+          node-version: 'lts/fermium'        
+
       - name: Install npm dependencies
         if: always()
         run: |

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -27,9 +27,7 @@ Supported languages are:
 
 ## Prerequisites
 
-To run all the linters please install for your OS:
-
-* [npm](https://github.com/nodesource/distributions)
+This repository is aligned to the Node.js 14 Maintenance LTS version of [Node.js](https://nodejs.org/en/) (which includes npm). Install the v14 (`lts/fremium`) version of Node.js which is available from [Node.js - Previous Releases](https://nodejs.org/en/download/releases/) page.
 
 ## Installation
 
@@ -58,7 +56,7 @@ Every individual check can be run like so:
 npm runscript my-individual-check
 ```
 
-See the package.json file for help.
+See the [package.json](https://github.com/corona-warn-app/cwa-documentation/blob/master/package.json) file for the currently available scripts.
 
 #### Markdown linter
 


### PR DESCRIPTION
This PR resolves [Repository update to Node v16 (or lock to Node v14)](https://github.com/corona-warn-app/cwa-documentation/issues/763) and locks the [cwa-documentation](https://github.com/corona-warn-app/cwa-documentation) repository to use Nodejs v14 (`lts/fermium`) as defined in https://nodejs.org/en/about/releases/ which is node v14.18.1 (with npm v6.14.15).

This keeps the [cwa-documentation](https://github.com/corona-warn-app/cwa-documentation) repository on the same node v14 version as used on the [cwa-website](https://github.com/corona-warn-app/cwa-website) repository, making it easier to work on both repositories from the same environment.