### PR TITLE
Correct Apache license syntax (resolves #765)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,5 @@
     "docs"
   ],
   "author": "Johannes Amorosa",
-  "license": "Apache 2.0"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-documentation/issues/765 by correcting the syntax of

`"license": "Apache 2.0"` in [package.json](https://github.com/corona-warn-app/cwa-documentation/blob/master/package.json) to `"license": "Apache-2.0"` by adding a hyphen "-".

Executing `npm install` should no longer output the warning:

```
npm WARN docs@1.0.0 license should be a valid SPDX license expression
```
after this change.