### PR TITLE
Use "Website" instead of "Web Site"

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
     <a href="#our-documentation">Our Documentation</a> •
     <a href="#licensing">Licensing</a> •
     <a href="#how-to-contribute">How to Contribute</a> •
-    <a href="https://www.coronawarn.app/en/">Web Site</a>
+    <a href="https://www.coronawarn.app/en/">Website</a>
 </p>
 <hr />
 


### PR DESCRIPTION
## Description

This PR removes the dated spelling "Web site" and replace it with "Website" in the README.md file.