### PR TITLE
Correct link to Risk Calculation in Solution Architecture document

### DIFF
--- a/cwa-risk-assessment.md
+++ b/cwa-risk-assessment.md
@@ -155,7 +155,7 @@ Betty's updated risk notification now shows 2 risk encounters, the most recent o
 
 ## Current Configuration
 
-As documented in the [risk score calculation section](https://github.com/corona-warn-app/cwa-documentation/blob/master/solution_architecture.md#risk-score-calculation) of the solution architecture document, the actual parameters for the calculation are provided by a set of parameters which are hosted on cwa-server.
+As documented in the [Risk Calculation](solution_architecture.md#risk-calculation) section of the solution architecture document, the actual parameters for the calculation are provided by a set of parameters which are hosted on cwa-server.
 This configuration might change over time according to the new research results and insights. The respective current set of configuration values can be looked up in the [cwa-server repository](https://github.com/corona-warn-app/cwa-server):
 
 - [Exposure Configuration](https://github.com/corona-warn-app/cwa-server/blob/master/services/distribution/src/main/resources/main-config/exposure-config.yaml)

--- a/translations/cwa-risk-assessment.de.md
+++ b/translations/cwa-risk-assessment.de.md
@@ -156,7 +156,7 @@ Bettys aktualisierte Risikobenachrichtigung zeigt jetzt 2 Risikobegegnungen an, 
 
 ## Aktuelle Konfiguration
 
-Wie im [Abschnitt "*Risk Score Calculation*"](https://github.com/corona-warn-app/cwa-documentation/blob/master/solution_architecture.md#risk-score-calculation) des *Solution-Architecture*-Dokuments beschrieben, werden die jeweiligen Parameter für die Berechnung aus von einer Menge an Parametern bestimmt, die vom CWA-Server zur Verfügung gestellt werden.
+Wie im [Abschnitt "*Risk Calculation*"](../solution_architecture.md#risk-calculation) des *Solution-Architecture*-Dokuments beschrieben, werden die jeweiligen Parameter für die Berechnung aus von einer Menge an Parametern bestimmt, die vom CWA-Server zur Verfügung gestellt werden.
 Diese Konfiguration kann sich über die Zeit auf Basis neuer Forschungsergebnisse und Erkentnisse ändern.
 Die jeweils aktuell gültigen Parameterwerte können im [*CWA-Server-Repository*](https://github.com/corona-warn-app/cwa-server) eingesehen werden:
 


### PR DESCRIPTION
This PR corrects links in the two documents:

- [How does the Corona-Warn-App identify an increased risk?](https://github.com/corona-warn-app/cwa-documentation/blob/master/cwa-risk-assessment.md) and
- [Wie ermittelt die Corona-Warn-App ein erhöhtes Risiko?](https://github.com/corona-warn-app/cwa-documentation/blob/master/translations/cwa-risk-assessment.de.md)

to the 

- [Risk Calculation](https://github.com/corona-warn-app/cwa-documentation/blob/master/solution_architecture.md#risk-calculation) section

in the

- [Solution Architecture ](https://github.com/corona-warn-app/cwa-documentation/blob/master/solution_architecture.md) document.