### PR TITLE
docs: deprecate cwa-risk-assessment.md

### DIFF
--- a/cwa-risk-assessment.md
+++ b/cwa-risk-assessment.md
@@ -1,5 +1,21 @@
 # How does the Corona-Warn-App identify an increased risk?
 
+An up-to-date description of how the risk assessment and risk calculation in the Corona-Warn-App works is available in the [Solution Architecture > Mobile Application](/solution_architecture.md#mobile-applications).
+
+Please note that this document is _not_ up-to-date anymore. It reflects the original risk assessment for Corona-Warn-App Release < 1.8 (approximately December 2020) and is kept here for documentation purposes only.
+
+
+<br /><br /><br /><br />
+
+
+# DEPRECATION NOTICE
+
+**The below content is not up-to-date anymore!**
+
+<br /><br /><br /><br />
+
+
+
 ---
 **Later calculation improvements**
 

--- a/cwa-risk-assessment.md
+++ b/cwa-risk-assessment.md
@@ -4,17 +4,13 @@ An up-to-date description of how the risk assessment and risk calculation in the
 
 Please note that this document is _not_ up-to-date anymore. It reflects the original risk assessment for Corona-Warn-App Release < 1.8 (approximately December 2020) and is kept here for documentation purposes only.
 
-
 <br /><br /><br /><br />
 
-
-# DEPRECATION NOTICE
+## DEPRECATION NOTICE
 
 **The below content is not up-to-date anymore!**
 
 <br /><br /><br /><br />
-
-
 
 ---
 **Later calculation improvements**

--- a/cwa-risk-assessment.md
+++ b/cwa-risk-assessment.md
@@ -1,21 +1,10 @@
 # How does the Corona-Warn-App identify an increased risk?
 
-An up-to-date description of how the risk assessment and risk calculation in the Corona-Warn-App works is available in the [Solution Architecture > Mobile Application](./solution_architecture.md#mobile-applications).
+Please note that this document is _not_ up-to-date anymore. It reflects the original risk assessment for the Corona-Warn-App before version 1.5 (released in October 2020) and is kept here for historical reference only. An up-to-date description of risk assessment and risk calculation in the Corona-Warn-App is available in the [Solution Architecture > Mobile Application](./solution_architecture.md#mobile-applications) document section.
 
-Please note that this document is _not_ up-to-date anymore. It reflects the original risk assessment for Corona-Warn-App Release < 1.8 (approximately December 2020) and is kept here for documentation purposes only.
-
-<br /><br /><br /><br />
-
-## DEPRECATION NOTICE
-
-**The below content is not up-to-date anymore!**
-
-<br /><br /><br /><br />
-
----
-**Later calculation improvements**
-
-Improvements to the risk assessment calculations were made in app versions [V1.5 (Symptom Recording)](https://www.coronawarn.app/en/blog/2020-10-19-version-1-5/) and [V1.9 (Exposure Notification Framework v2)](https://www.coronawarn.app/en/blog/2020-12-16-corona-warn-app-version-1-9/) after this document was published. The FAQ section [Risk Assessment](https://www.coronawarn.app/en/faq/#risk_assessment) answers related questions.
+DEPRECATION NOTICE |
+--- |
+**The content of this document is not up-to-date and is no longer maintained.**
 
 ---
 

--- a/cwa-risk-assessment.md
+++ b/cwa-risk-assessment.md
@@ -2,9 +2,13 @@
 
 Please note that this document is _not_ up-to-date anymore. It reflects the original risk assessment for the Corona-Warn-App before version 1.5 (released in October 2020) and is kept here for historical reference only. An up-to-date description of risk assessment and risk calculation in the Corona-Warn-App is available in the [Solution Architecture > Mobile Application](./solution_architecture.md#mobile-applications) document section.
 
-DEPRECATION NOTICE |
---- |
+<br /><br />
+
+## DEPRECATION NOTICE
+
 **The content of this document is not up-to-date and is no longer maintained.**
+
+<br /><br />
 
 ---
 

--- a/cwa-risk-assessment.md
+++ b/cwa-risk-assessment.md
@@ -1,6 +1,6 @@
 # How does the Corona-Warn-App identify an increased risk?
 
-An up-to-date description of how the risk assessment and risk calculation in the Corona-Warn-App works is available in the [Solution Architecture > Mobile Application](/solution_architecture.md#mobile-applications).
+An up-to-date description of how the risk assessment and risk calculation in the Corona-Warn-App works is available in the [Solution Architecture > Mobile Application](./solution_architecture.md#mobile-applications).
 
 Please note that this document is _not_ up-to-date anymore. It reflects the original risk assessment for Corona-Warn-App Release < 1.8 (approximately December 2020) and is kept here for documentation purposes only.
 

--- a/cwa-risk-assessment.md
+++ b/cwa-risk-assessment.md
@@ -4,7 +4,7 @@ Please note that this document is _not_ up-to-date anymore. It reflects the orig
 
 <br /><br />
 
-## DEPRECATION NOTICE
+## IMPORTANT! - DEPRECATION NOTICE
 
 **The content of this document is not up-to-date and is no longer maintained.**
 

--- a/translations/cwa-risk-assessment.de.md
+++ b/translations/cwa-risk-assessment.de.md
@@ -2,9 +2,13 @@
 
 Dieses Dokument ist **nicht mehr aktuell**. Es beschreibt die ursprüngliche Risikoberechnung in der Corona-Warn-App vor Version 1.5 (in Oktober 2020 freigegeben) und wird hier aus Dokumentationsgründen noch beibehalten. Eine aktuelle Beschreibung der Risikoanalyse und -berechnung in der Corona-Warn-App befindet sich im Dokumentenabschnitt [Solution Architecture > Mobile Application](../solution_architecture.md#mobile-applications) (auf Englisch).
 
-WICHTIG! - DOKUMENT ZURÜCKGEZOGEN |
---- |
+<br /><br />
+
+## WICHTIG! - DOKUMENT ZURÜCKGEZOGEN
+
 **Der Inhalt dieses Dokuments entspricht nicht mehr dem aktuellen Stand und wird nicht weiter gepflegt.**
+
+<br /><br />
 
 ---
 

--- a/translations/cwa-risk-assessment.de.md
+++ b/translations/cwa-risk-assessment.de.md
@@ -1,9 +1,10 @@
 # Wie ermittelt die Corona-Warn-App ein erhöhtes Risiko?
 
----
-**Nachträgliche Verbesserungen der Risikoberechnung**
+Dieses Dokument ist **nicht mehr aktuell**. Es beschreibt die ursprüngliche Risikoberechnung in der Corona-Warn-App vor Version 1.5 (in Oktober 2020 freigegeben) und wird hier aus Dokumentationsgründen noch beibehalten. Eine aktuelle Beschreibung der Risikoanalyse und -berechnung in der Corona-Warn-App befindet sich im Dokumentenabschnitt [Solution Architecture > Mobile Application](../solution_architecture.md#mobile-applications) (auf Englisch).
 
-Verbesserungen der Risikoberechnung sind mit den App-Versionen [V1.5 (Symptomerfassung)](https://www.coronawarn.app/de/blog/2020-10-19-version-1-5/) bzw. [V1.9 (Exposure Notification Framework v2)](https://www.coronawarn.app/de/blog/2020-12-16-corona-warn-app-version-1-9/) nach der Veröffentlichung dieses Dokuments eingeführt worden. Im FAQ-Abschnitt [Risiko-Ermittlung](https://www.coronawarn.app/de/faq/#risk_assessment) werden diesbezügliche Fragen beantwortet.
+WICHTIG! - DOKUMENT ZURÜCKGEZOGEN |
+--- |
+**Der Inhalt dieses Dokuments entspricht nicht mehr dem aktuellen Stand und wird nicht weiter gepflegt.**
 
 ---
 
@@ -157,7 +158,7 @@ Bettys aktualisierte Risikobenachrichtigung zeigt jetzt 2 Risikobegegnungen an, 
 ## Aktuelle Konfiguration
 
 Wie im [Abschnitt "*Risk Calculation*"](../solution_architecture.md#risk-calculation) des *Solution-Architecture*-Dokuments beschrieben, werden die jeweiligen Parameter für die Berechnung aus von einer Menge an Parametern bestimmt, die vom CWA-Server zur Verfügung gestellt werden.
-Diese Konfiguration kann sich über die Zeit auf Basis neuer Forschungsergebnisse und Erkentnisse ändern.
+Diese Konfiguration kann sich über die Zeit auf Basis neuer Forschungsergebnisse und Erkenntnisse ändern.
 Die jeweils aktuell gültigen Parameterwerte können im [*CWA-Server-Repository*](https://github.com/corona-warn-app/cwa-server) eingesehen werden:
 
 - [Konfiguration von Begegnungen](https://github.com/corona-warn-app/cwa-server/blob/master/services/distribution/src/main/resources/main-config/exposure-config.yaml)

--- a/translations/cwa-risk-assessment.de.md
+++ b/translations/cwa-risk-assessment.de.md
@@ -1,6 +1,6 @@
 # Wie ermittelt die Corona-Warn-App ein erhöhtes Risiko?
 
-Dieses Dokument ist **nicht mehr aktuell**. Es beschreibt die ursprüngliche Risikoberechnung in der Corona-Warn-App vor Version 1.5 (in Oktober 2020 freigegeben) und wird hier aus Dokumentationsgründen noch beibehalten. Eine aktuelle Beschreibung der Risikoanalyse und -berechnung in der Corona-Warn-App befindet sich im Dokumentenabschnitt [Solution Architecture > Mobile Application](../solution_architecture.md#mobile-applications) (auf Englisch).
+Dieses Dokument ist **nicht mehr aktuell**. Es beschreibt die ursprüngliche Risikoberechnung in der Corona-Warn-App vor Version 1.5 (im Oktober 2020 veröffentlicht) und wird hier aus Dokumentationsgründen noch beibehalten. Eine aktuelle Beschreibung der Risikoanalyse und -berechnung in der Corona-Warn-App befindet sich im Dokumentenabschnitt [Solution Architecture > Mobile Application](../solution_architecture.md#mobile-applications) (auf Englisch).
 
 <br /><br />
 

--- a/translations/cwa-risk-assessment.de.md
+++ b/translations/cwa-risk-assessment.de.md
@@ -1,6 +1,6 @@
 # Wie ermittelt die Corona-Warn-App ein erhöhtes Risiko?
 
-Dieses Dokument ist **nicht mehr aktuell**. Es beschreibt die ursprüngliche Risikoberechnung in der Corona-Warn-App vor Version 1.5 (im Oktober 2020 veröffentlicht) und wird hier aus Dokumentationsgründen noch beibehalten. Eine aktuelle Beschreibung der Risikoanalyse und -berechnung in der Corona-Warn-App befindet sich im Dokumentenabschnitt [Solution Architecture > Mobile Application](../solution_architecture.md#mobile-applications) (auf Englisch).
+Dieses Dokument ist **nicht mehr aktuell**. Es beschreibt die ursprüngliche Risikoberechnung in der Corona-Warn-App vor Version 1.5 (im Oktober 2020 veröffentlicht) und wird hier aus Dokumentationsgründen noch beibehalten. Eine aktuelle Beschreibung der Risikoanalyse und Risikoberechnung in der Corona-Warn-App befindet sich im Dokumentenabschnitt [Solution Architecture > Mobile Application](../solution_architecture.md#mobile-applications) (auf Englisch).
 
 <br /><br />
 


### PR DESCRIPTION
- add deprecation notice to document
- add reference to solution architecture

related to #453

**Background:**

We realistically don't have enough time at the moment to rework the document. At the same time, there is a pretty detailed description of the risk assessment and risk calculation in the Solution Architecture, which reflects what CWA is currently doing.

Instead of completely deleting the file, we propose to add a deprecation notice instead and point to the respective section in the Solution Architecture.