### PR TITLE
Deprecate cwa-risk-assessment in EN and DE

### DIFF
--- a/cwa-risk-assessment.md
+++ b/cwa-risk-assessment.md
@@ -1,21 +1,10 @@
 # How does the Corona-Warn-App identify an increased risk?
 
-An up-to-date description of how the risk assessment and risk calculation in the Corona-Warn-App works is available in the [Solution Architecture > Mobile Application](./solution_architecture.md#mobile-applications).
+Please note that this document is _not_ up-to-date anymore. It reflects the original risk assessment for the Corona-Warn-App before version 1.5 (released in October 2020) and is kept here for historical reference only. An up-to-date description of risk assessment and risk calculation in the Corona-Warn-App is available in the [Solution Architecture > Mobile Application](./solution_architecture.md#mobile-applications) document section.
 
-Please note that this document is _not_ up-to-date anymore. It reflects the original risk assessment for Corona-Warn-App Release < 1.8 (approximately December 2020) and is kept here for documentation purposes only.
-
-<br /><br /><br /><br />
-
-## DEPRECATION NOTICE
-
-**The below content is not up-to-date anymore!**
-
-<br /><br /><br /><br />
-
----
-**Later calculation improvements**
-
-Improvements to the risk assessment calculations were made in app versions [V1.5 (Symptom Recording)](https://www.coronawarn.app/en/blog/2020-10-19-version-1-5/) and [V1.9 (Exposure Notification Framework v2)](https://www.coronawarn.app/en/blog/2020-12-16-corona-warn-app-version-1-9/) after this document was published. The FAQ section [Risk Assessment](https://www.coronawarn.app/en/faq/#risk_assessment) answers related questions.
+DEPRECATION NOTICE |
+--- |
+**The content of this document is not up-to-date and is no longer maintained.**
 
 ---
 

--- a/translations/cwa-risk-assessment.de.md
+++ b/translations/cwa-risk-assessment.de.md
@@ -1,9 +1,10 @@
 # Wie ermittelt die Corona-Warn-App ein erhöhtes Risiko?
 
----
-**Nachträgliche Verbesserungen der Risikoberechnung**
+Dieses Dokument ist **nicht mehr aktuell**. Es beschreibt die ursprüngliche Risikoberechnung in der Corona-Warn-App vor Version 1.5 (in Oktober 2020 freigegeben) und wird hier aus Dokumentationsgründen noch beibehalten. Eine aktuelle Beschreibung der Risikoanalyse und -berechnung in der Corona-Warn-App befindet sich im Dokumentenabschnitt [Solution Architecture > Mobile Application](../solution_architecture.md#mobile-applications) (auf Englisch).
 
-Verbesserungen der Risikoberechnung sind mit den App-Versionen [V1.5 (Symptomerfassung)](https://www.coronawarn.app/de/blog/2020-10-19-version-1-5/) bzw. [V1.9 (Exposure Notification Framework v2)](https://www.coronawarn.app/de/blog/2020-12-16-corona-warn-app-version-1-9/) nach der Veröffentlichung dieses Dokuments eingeführt worden. Im FAQ-Abschnitt [Risiko-Ermittlung](https://www.coronawarn.app/de/faq/#risk_assessment) werden diesbezügliche Fragen beantwortet.
+WICHTIG! - DOKUMENT ZURÜCKGEZOGEN |
+--- |
+**Der Inhalt dieses Dokuments entspricht nicht mehr dem aktuellen Stand und wird nicht weiter gepflegt.**
 
 ---
 
@@ -157,7 +158,7 @@ Bettys aktualisierte Risikobenachrichtigung zeigt jetzt 2 Risikobegegnungen an, 
 ## Aktuelle Konfiguration
 
 Wie im [Abschnitt "*Risk Calculation*"](../solution_architecture.md#risk-calculation) des *Solution-Architecture*-Dokuments beschrieben, werden die jeweiligen Parameter für die Berechnung aus von einer Menge an Parametern bestimmt, die vom CWA-Server zur Verfügung gestellt werden.
-Diese Konfiguration kann sich über die Zeit auf Basis neuer Forschungsergebnisse und Erkentnisse ändern.
+Diese Konfiguration kann sich über die Zeit auf Basis neuer Forschungsergebnisse und Erkenntnisse ändern.
 Die jeweils aktuell gültigen Parameterwerte können im [*CWA-Server-Repository*](https://github.com/corona-warn-app/cwa-server) eingesehen werden:
 
 - [Konfiguration von Begegnungen](https://github.com/corona-warn-app/cwa-server/blob/master/services/distribution/src/main/resources/main-config/exposure-config.yaml)


### PR DESCRIPTION
@mlenkeit 

I pulled in the German cwa-risk-assessment document and rearranged the information in the English language one.

Feel free to use or ignore! It is a PR on top of your PR #829.

**EN**

![image](https://user-images.githubusercontent.com/66998419/151999807-7efc43e8-4487-4b5e-a0b5-4eff353288d0.png)

**DE**

![image](https://user-images.githubusercontent.com/66998419/151999998-c8b6b7de-dbe2-493a-850a-c85fb18568fa.png)

