### PR TITLE
Disable link checking for breg links

### DIFF
--- a/glossary.md
+++ b/glossary.md
@@ -48,5 +48,8 @@ This overview provides a description for all acronyms and special terms which ar
 
 To access the glossaries, scroll down the page to the Glossary / Glossar section:
 
+<!-- markdown-link-check-disable -->
+<!-- avoids HTTP 503 error due to security measures of https://www.bundesregierung.de -->
 - [English FAQs](https://www.bundesregierung.de/corona-warn-app-faq-englisch)
 - [German FAQs](https://www.bundesregierung.de/corona-warn-app-faq)
+<!-- markdown-link-check-enable -->


### PR DESCRIPTION
This PR resolves issue https://github.com/corona-warn-app/cwa-documentation/issues/846 "checklinks fails checking https://www.bundesregierung.de/corona-warn-app-faq" caused by network security on the https://www.bundesregierung.de website.

It disables link checking in https://github.com/corona-warn-app/cwa-documentation/glossary.md for the problematic links:

- https://www.bundesregierung.de/corona-warn-app-faq-englisch
- https://www.bundesregierung.de/corona-warn-app-faq

which otherwise may return a HTTP 503 "Service Unavailable" error when attempting to check their availability using `markdown-check-lint`.

## Verification

Execute
`npm run checklinks`
and ensure that no errors are reported.