### PR TITLE
Correct case in CONTRIBUTING.md to Pull Request Checklist header

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ Should you wish to work on an issue, please claim it first by commenting on the 
 
 If you have questions about one of the issues, please comment on them, and one of the maintainers will clarify.
 
-We kindly ask you to follow the [Pull Request Checklist](#Pull-Request-Checklist) to ensure reviews can happen accordingly.
+We kindly ask you to follow the [Pull Request Checklist](#pull-request-checklist) to ensure reviews can happen accordingly.
 
 ## Contributing Code
 


### PR DESCRIPTION
This PR resolves a case mismatch in a link in [CONTRIBUTING.md](https://github.com/corona-warn-app/cwa-documentation/blob/main/CONTRIBUTING.md).

The correct absolute link is https://github.com/corona-warn-app/cwa-documentation/blob/main/CONTRIBUTING.md#pull-request-checklist (hover to the left of the heading "Pull Request Checklist" in [CONTRIBUTING.md](https://github.com/corona-warn-app/cwa-documentation/blob/main/CONTRIBUTING.md) to view). The correct relative link is `#pull-request-checklist` not `#Pull-Request-Checklist`. 

GitHub is insensitive to the mismatch. On the other hand, Visual Studio Code fails with the link in "Open Preview" mode and the problem is flagged by the latest version of [markdown-link-check](https://github.com/tcort/markdown-link-check) 3.10.2.