### PR TITLE
Sync package-lock.json to package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "docs",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "docs",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "alex": "^8.2.0",
@@ -14,8 +14,7 @@
         "markdownlint": "^0.20.4",
         "markdownlint-cli": "^0.23.2",
         "npm-run-all": "^4.1.5"
-      },
-      "devDependencies": {}
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.16.7",


### PR DESCRIPTION
This PR synchronizes the header section of [package-lock.json](https://github.com/corona-warn-app/cwa-documentation/blob/main/package-lock.json) to match the contents of [package.json](https://github.com/corona-warn-app/cwa-documentation/blob/main/package.json).

It corrects an error introduced in PR #894 where npm should have automatically updated the `version` field and removed the empty `devDependencies` field when it updated [package-lock.json](https://github.com/corona-warn-app/cwa-documentation/blob/main/package-lock.json).

If it is not corrected, then `git` will show an uncommitted change if `npm install` is run.

## Verification

Execute
`npm run install-test`

with no errors recorded.

Execute
`git status`

with no uncommitted changes shown.