### PR TITLE
Update Node.js 16 status to Maintenance

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ This repository checks against following specification:
 
 ## Prerequisites
 
-Install the Node.js 16 Active LTS version of [Node.js](https://nodejs.org/en/) (which includes npm).
+Install the Node.js 16 Maintenance version of [Node.js](https://nodejs.org/en/) (which includes npm).
 
 ## Installation
 


### PR DESCRIPTION
This PR updates the reference to Node.js 16 in the [INSTALL.md Prerequisites](https://github.com/corona-warn-app/cwa-documentation/blob/main/INSTALL.md#prerequisites) file section.

According to https://github.com/nodejs/release#release-schedule Node.js 16 is now in *Maintenance* status instead of the previous *Active LTS* status.

Note: Node.js 18.x now becomes the Active LTS version (see https://nodejs.org/en/blog/release/v18.12.0/ from Oct 25, 2022).