### PR TITLE
Resolve workflow deprecation notice

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -12,10 +12,10 @@ jobs:
           sudo apt install -y automake npm nodejs
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Node.js environment (v16)
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 'lts/gallium'        
 


### PR DESCRIPTION
This PR resolves an issue where https://github.com/corona-warn-app/cwa-documentation/actions/workflows/checks.yml shows the deprecation notice:

"Build

Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, actions/setup-node, actions/setup-node, actions/checkout"

by updating 

[cwa-documentation/actions](https://github.com/corona-warn-app/cwa-documentation/actions) as follows:

- `actions/checkout@v2` to `v3`
- `actions/setup-node@v2` to `v3`

---
Internal Tracking ID: [EXPOSUREAPP-14242](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14242)
