### PR TITLE
Migrate check workflow to Node.js 18

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
-      - name: Setup Node.js environment (v16)
+      - name: Setup Node.js 18 environment
         uses: actions/setup-node@v3
         with:
-          node-version: 'lts/gallium'        
+          node-version: 'lts/hydrogen'       
 
       - name: Install npm dependencies
         if: always()

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -20,7 +20,7 @@ This repository checks against following specification:
 
 ## Prerequisites
 
-Install the Node.js 16 Maintenance version of [Node.js](https://nodejs.org/en/) (which includes npm).
+Install the Node.js 18 Active LTS version of [Node.js](https://nodejs.org/en/) (which includes npm).
 
 ## Installation
 


### PR DESCRIPTION
This PR updates Node.js to 18 (`lts/hydrogen`) in the [workflows/checks.yml](https://github.com/corona-warn-app/cwa-documentation/blob/main/.github/workflows/checks.yml) file.

This is in alignment with the [cwa-website](https://github.com/corona-warn-app/cwa-website).

## Verification

`npm test`

and ensure that there are no errors reported.

Examine the [Actions log](https://github.com/corona-warn-app/cwa-documentation/actions) and make sure that there are no errors.

---
Internal Tracking ID: [EXPOSUREAPP-14275](https://jira-ibs.wbs.net.sap/browse/EXPOSUREAPP-14275)
